### PR TITLE
Fix tests not passing.

### DIFF
--- a/Source/UIImage+Hue.swift
+++ b/Source/UIImage+Hue.swift
@@ -13,7 +13,7 @@ class CountedColor {
 extension UIImage {
 
   private func resize(newSize: CGSize) -> UIImage {
-    UIGraphicsBeginImageContextWithOptions(newSize, false, 0)
+    UIGraphicsBeginImageContextWithOptions(newSize, false, 2)
     drawInRect(CGRectMake(0, 0, newSize.width, newSize.height))
     let result = UIGraphicsGetImageFromCurrentImageContext()
     UIGraphicsEndImageContext()


### PR DESCRIPTION
This PR fixes the issue that the `resize` rendered different results depending on the device you are running it on.

This caused the tests to fail on all `Plus` iPhone because
it used a different image size for analysis.
