### PR TITLE
Initial Mac version

### DIFF
--- a/Hue.podspec
+++ b/Hue.podspec
@@ -14,4 +14,8 @@ Pod::Spec.new do |s|
   s.ios.source_files = 'Source/iOS/**/*'
 
   s.ios.frameworks = 'UIKit'
+
+  s.osx.deployment_target = '10.10'
+  s.osx.source_files = 'Source/Mac/**/*'
+  s.osx.frameworks = 'AppKit'
 end

--- a/Hue.xcodeproj/project.pbxproj
+++ b/Hue.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Hue/Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-Mac";
 				PRODUCT_NAME = Hue;
 				SDKROOT = macosx;
@@ -460,7 +460,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Hue/Mac/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-Mac";
 				PRODUCT_NAME = Hue;
 				SDKROOT = macosx;

--- a/Hue.xcodeproj/project.pbxproj
+++ b/Hue.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3868879B1C8343D0005A8868 /* Hue.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 386887911C8343CF005A8868 /* Hue.framework */; };
+		386887AC1C83442A005A8868 /* NSColor+Hue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386887AA1C83442A005A8868 /* NSColor+Hue.swift */; };
+		386887AE1C83442A005A8868 /* NSImage+Hue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386887AB1C83442A005A8868 /* NSImage+Hue.swift */; };
+		386887B91C834591005A8868 /* NSColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386887B71C834591005A8868 /* NSColorTests.swift */; };
+		386887BA1C834591005A8868 /* NSImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 386887B81C834591005A8868 /* NSImageTests.swift */; };
+		386887C11C834665005A8868 /* Random Access Memories.png in Resources */ = {isa = PBXBuildFile; fileRef = D5EEA20F1C3EAE01000F8F1B /* Random Access Memories.png */; };
 		D528621D1C3EAC1D00AD11AD /* Hue.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D52862121C3EAC1D00AD11AD /* Hue.framework */; };
 		D5EEA2211C3EAE0A000F8F1B /* Random Access Memories.png in Resources */ = {isa = PBXBuildFile; fileRef = D5EEA20F1C3EAE01000F8F1B /* Random Access Memories.png */; };
 		D5EEA2221C3EAE25000F8F1B /* UIColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5EEA2151C3EAE01000F8F1B /* UIColorTests.swift */; };
@@ -16,6 +22,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3868879C1C8343D0005A8868 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D52862091C3EAC1D00AD11AD /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 386887901C8343CF005A8868;
+			remoteInfo = "Hue-Mac";
+		};
 		D528621E1C3EAC1D00AD11AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D52862091C3EAC1D00AD11AD /* Project object */;
@@ -26,6 +39,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		386887911C8343CF005A8868 /* Hue.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hue.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3868879A1C8343D0005A8868 /* Hue-MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Hue-MacTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		386887AA1C83442A005A8868 /* NSColor+Hue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSColor+Hue.swift"; sourceTree = "<group>"; };
+		386887AB1C83442A005A8868 /* NSImage+Hue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSImage+Hue.swift"; sourceTree = "<group>"; };
+		386887B21C834567005A8868 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		386887B71C834591005A8868 /* NSColorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSColorTests.swift; sourceTree = "<group>"; };
+		386887B81C834591005A8868 /* NSImageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSImageTests.swift; sourceTree = "<group>"; };
+		386887BD1C8345C4005A8868 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D52862121C3EAC1D00AD11AD /* Hue.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hue.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D528621C1C3EAC1D00AD11AD /* Hue-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Hue-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5EEA20F1C3EAE01000F8F1B /* Random Access Memories.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Random Access Memories.png"; sourceTree = "<group>"; };
@@ -38,6 +59,21 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3868878D1C8343CF005A8868 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		386887971C8343D0005A8868 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3868879B1C8343D0005A8868 /* Hue.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D528620E1C3EAC1D00AD11AD /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -56,6 +92,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		386887A91C83442A005A8868 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				386887AA1C83442A005A8868 /* NSColor+Hue.swift */,
+				386887AB1C83442A005A8868 /* NSImage+Hue.swift */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		386887B01C834567005A8868 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				386887B71C834591005A8868 /* NSColorTests.swift */,
+				386887B81C834591005A8868 /* NSImageTests.swift */,
+				386887B21C834567005A8868 /* Info.plist */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		386887BB1C8345C4005A8868 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				386887BD1C8345C4005A8868 /* Info.plist */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
 		D52862081C3EAC1D00AD11AD = {
 			isa = PBXGroup;
 			children = (
@@ -71,6 +134,8 @@
 			children = (
 				D52862121C3EAC1D00AD11AD /* Hue.framework */,
 				D528621C1C3EAC1D00AD11AD /* Hue-iOS-Tests.xctest */,
+				386887911C8343CF005A8868 /* Hue.framework */,
+				3868879A1C8343D0005A8868 /* Hue-MacTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -78,6 +143,7 @@
 		D5EEA20D1C3EAE01000F8F1B /* Hue */ = {
 			isa = PBXGroup;
 			children = (
+				386887BB1C8345C4005A8868 /* Mac */,
 				D5EEA20E1C3EAE01000F8F1B /* Assets */,
 				D5EEA2101C3EAE01000F8F1B /* iOS */,
 			);
@@ -103,6 +169,7 @@
 		D5EEA2121C3EAE01000F8F1B /* HueTests */ = {
 			isa = PBXGroup;
 			children = (
+				386887B01C834567005A8868 /* Mac */,
 				D5EEA2131C3EAE01000F8F1B /* iOS */,
 			);
 			path = HueTests;
@@ -121,6 +188,7 @@
 		D5EEA2241C3EB008000F8F1B /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				386887A91C83442A005A8868 /* Mac */,
 				D5EEA2251C3EB008000F8F1B /* iOS */,
 			);
 			path = Source;
@@ -138,6 +206,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		3868878E1C8343CF005A8868 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D528620F1C3EAC1D00AD11AD /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -148,6 +223,42 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		386887901C8343CF005A8868 /* Hue-Mac */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 386887A61C8343D0005A8868 /* Build configuration list for PBXNativeTarget "Hue-Mac" */;
+			buildPhases = (
+				3868878C1C8343CF005A8868 /* Sources */,
+				3868878D1C8343CF005A8868 /* Frameworks */,
+				3868878E1C8343CF005A8868 /* Headers */,
+				3868878F1C8343CF005A8868 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Hue-Mac";
+			productName = "Hue-Mac";
+			productReference = 386887911C8343CF005A8868 /* Hue.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		386887991C8343D0005A8868 /* Hue-MacTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 386887A71C8343D0005A8868 /* Build configuration list for PBXNativeTarget "Hue-MacTests" */;
+			buildPhases = (
+				386887961C8343D0005A8868 /* Sources */,
+				386887971C8343D0005A8868 /* Frameworks */,
+				386887981C8343D0005A8868 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3868879D1C8343D0005A8868 /* PBXTargetDependency */,
+			);
+			name = "Hue-MacTests";
+			productName = "Hue-MacTests";
+			productReference = 3868879A1C8343D0005A8868 /* Hue-MacTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		D52862111C3EAC1D00AD11AD /* Hue-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D52862261C3EAC1D00AD11AD /* Build configuration list for PBXNativeTarget "Hue-iOS" */;
@@ -194,6 +305,12 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Hyper Interaktiv AS";
 				TargetAttributes = {
+					386887901C8343CF005A8868 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
+					386887991C8343D0005A8868 = {
+						CreatedOnToolsVersion = 7.2.1;
+					};
 					D52862111C3EAC1D00AD11AD = {
 						CreatedOnToolsVersion = 7.2;
 					};
@@ -208,6 +325,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = D52862081C3EAC1D00AD11AD;
 			productRefGroup = D52862131C3EAC1D00AD11AD /* Products */;
@@ -216,11 +334,28 @@
 			targets = (
 				D52862111C3EAC1D00AD11AD /* Hue-iOS */,
 				D528621B1C3EAC1D00AD11AD /* Hue-iOS-Tests */,
+				386887901C8343CF005A8868 /* Hue-Mac */,
+				386887991C8343D0005A8868 /* Hue-MacTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3868878F1C8343CF005A8868 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		386887981C8343D0005A8868 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				386887C11C834665005A8868 /* Random Access Memories.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D52862101C3EAC1D00AD11AD /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -239,6 +374,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3868878C1C8343CF005A8868 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				386887AC1C83442A005A8868 /* NSColor+Hue.swift in Sources */,
+				386887AE1C83442A005A8868 /* NSImage+Hue.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		386887961C8343D0005A8868 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				386887B91C834591005A8868 /* NSColorTests.swift in Sources */,
+				386887BA1C834591005A8868 /* NSImageTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D528620D1C3EAC1D00AD11AD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -260,6 +413,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3868879D1C8343D0005A8868 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 386887901C8343CF005A8868 /* Hue-Mac */;
+			targetProxy = 3868879C1C8343D0005A8868 /* PBXContainerItemProxy */;
+		};
 		D528621F1C3EAC1D00AD11AD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D52862111C3EAC1D00AD11AD /* Hue-iOS */;
@@ -268,6 +426,80 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		386887A21C8343D0005A8868 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/Hue/Mac/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-Mac";
+				PRODUCT_NAME = Hue;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		386887A31C8343D0005A8868 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = "$(SRCROOT)/Hue/Mac/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-Mac";
+				PRODUCT_NAME = Hue;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		386887A41C8343D0005A8868 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/**";
+				INFOPLIST_FILE = "$(SRCROOT)/HueTests/Mac/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-MacTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+			};
+			name = Debug;
+		};
+		386887A51C8343D0005A8868 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/**";
+				INFOPLIST_FILE = "$(SRCROOT)/HueTests/Mac/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.OHF.Hue-MacTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+			};
+			name = Release;
+		};
 		D52862241C3EAC1D00AD11AD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -414,6 +646,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		386887A61C8343D0005A8868 /* Build configuration list for PBXNativeTarget "Hue-Mac" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				386887A21C8343D0005A8868 /* Debug */,
+				386887A31C8343D0005A8868 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		386887A71C8343D0005A8868 /* Build configuration list for PBXNativeTarget "Hue-MacTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				386887A41C8343D0005A8868 /* Debug */,
+				386887A51C8343D0005A8868 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D528620C1C3EAC1D00AD11AD /* Build configuration list for PBXProject "Hue" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Hue.xcodeproj/xcshareddata/xcschemes/Hue-Mac.xcscheme
+++ b/Hue.xcodeproj/xcshareddata/xcschemes/Hue-Mac.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "386887901C8343CF005A8868"
+               BuildableName = "Hue.framework"
+               BlueprintName = "Hue-Mac"
+               ReferencedContainer = "container:Hue.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "386887991C8343D0005A8868"
+               BuildableName = "Hue-MacTests.xctest"
+               BlueprintName = "Hue-MacTests"
+               ReferencedContainer = "container:Hue.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "386887901C8343CF005A8868"
+            BuildableName = "Hue.framework"
+            BlueprintName = "Hue-Mac"
+            ReferencedContainer = "container:Hue.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "386887901C8343CF005A8868"
+            BuildableName = "Hue.framework"
+            BlueprintName = "Hue-Mac"
+            ReferencedContainer = "container:Hue.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "386887901C8343CF005A8868"
+            BuildableName = "Hue.framework"
+            BlueprintName = "Hue-Mac"
+            ReferencedContainer = "container:Hue.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Hue/Mac/Info.plist
+++ b/Hue/Mac/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/HueTests/Mac/Info.plist
+++ b/HueTests/Mac/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/HueTests/Mac/NSColorTests.swift
+++ b/HueTests/Mac/NSColorTests.swift
@@ -1,0 +1,88 @@
+@testable import Hue
+import AppKit
+import XCTest
+
+class NSColorTests: XCTestCase {
+
+  func testHex() {
+    let white = NSColor.hex("#FFFFFF")
+    let black = NSColor.hex("000000")
+    let red = NSColor.hex("F00")
+    let blue = NSColor.hex("#00F")
+    let green = NSColor.hex("#00FF00")
+    let yellow = NSColor.hex("#FFFF00")
+
+    XCTAssertEqual(white, NSColor(red: 255, green: 255, blue: 255, alpha: 1.0))
+    XCTAssertEqual(black, NSColor(red: 0, green: 0, blue: 0, alpha: 1.0))
+    XCTAssertEqual(red, NSColor(red: 255, green: 0, blue: 0, alpha: 1.0))
+    XCTAssertEqual(blue, NSColor(red: 0, green: 0, blue: 255, alpha: 1.0))
+    XCTAssertEqual(green, NSColor(red: 0, green: 255, blue: 0, alpha: 1.0))
+    XCTAssertEqual(yellow, NSColor(red: 255, green: 255, blue: 0, alpha: 1.0))
+  }
+
+  func testToHexWithPrefix() {
+    let white = NSColor.whiteColor()
+    let black = NSColor.blackColor()
+    let red = NSColor.redColor()
+    let blue = NSColor.blueColor()
+    let green = NSColor.greenColor()
+    let yellow = NSColor.yellowColor()
+
+    XCTAssertEqual(white.hex(), "#FFFFFF")
+    XCTAssertEqual(black.hex(), "#000000")
+    XCTAssertEqual(red.hex(), "#FF0000")
+    XCTAssertEqual(blue.hex(), "#0000FF")
+    XCTAssertEqual(green.hex(), "#00FF00")
+    XCTAssertEqual(yellow.hex(), "#FFFF00")
+  }
+
+  func testToHexWithoutPrefix() {
+    let white = NSColor.whiteColor()
+    let black = NSColor.blackColor()
+    let red = NSColor.redColor()
+    let blue = NSColor.blueColor()
+    let green = NSColor.greenColor()
+    let yellow = NSColor.yellowColor()
+
+    XCTAssertEqual(white.hex(withPrefix: false), "FFFFFF")
+    XCTAssertEqual(black.hex(withPrefix: false), "000000")
+    XCTAssertEqual(red.hex(withPrefix: false), "FF0000")
+    XCTAssertEqual(blue.hex(withPrefix: false), "0000FF")
+    XCTAssertEqual(green.hex(withPrefix: false), "00FF00")
+    XCTAssertEqual(yellow.hex(withPrefix: false), "FFFF00")
+  }
+
+  func testAlpha() {
+    let yellowWithAlpha = NSColor.hex("#FFFF00").alpha(0.5)
+
+    XCTAssertEqual(yellowWithAlpha, NSColor(red: 255, green: 255, blue: 0, alpha: 1.0).colorWithAlphaComponent(0.5))
+  }
+
+  func testGradient() {
+    let testGradient = [NSColor.blackColor(), NSColor.orangeColor()].gradient()
+
+    XCTAssertTrue(testGradient.isKindOfClass(CAGradientLayer))
+    XCTAssertEqual(testGradient.colors?.count, 2)
+    XCTAssertEqual(
+      CGColorSpaceGetModel(CGColorGetColorSpace((testGradient.colors as! [CGColor])[0])),
+      CGColorSpaceGetModel(CGColorGetColorSpace(NSColor.blackColor().CGColor)))
+    XCTAssertEqual(
+      CGColorSpaceGetModel(CGColorGetColorSpace((testGradient.colors as! [CGColor])[1])),
+      CGColorSpaceGetModel(CGColorGetColorSpace(NSColor.orangeColor().CGColor)))
+
+    let testGradientWithLocation = [NSColor.blueColor(), NSColor.yellowColor()].gradient { gradient in
+      gradient.locations = [0.25, 1.0]
+      return gradient
+    }
+
+    XCTAssertTrue(testGradient.isKindOfClass(CAGradientLayer))
+    XCTAssertEqual(testGradient.colors?.count, 2)
+    XCTAssertEqual(
+      CGColorSpaceGetModel(CGColorGetColorSpace((testGradientWithLocation.colors as! [CGColor])[0])),
+      CGColorSpaceGetModel(CGColorGetColorSpace(NSColor.blueColor().CGColor)))
+    XCTAssertEqual(
+      CGColorSpaceGetModel(CGColorGetColorSpace((testGradientWithLocation.colors as! [CGColor])[1])),
+      CGColorSpaceGetModel(CGColorGetColorSpace(NSColor.yellowColor().CGColor)))
+    XCTAssertEqual(testGradientWithLocation.locations!, [0.25,1.0])
+  }
+}

--- a/HueTests/Mac/NSImageTests.swift
+++ b/HueTests/Mac/NSImageTests.swift
@@ -1,0 +1,44 @@
+@testable import Hue
+import AppKit
+import XCTest
+
+class NSImageTests: XCTestCase {
+
+  func testImageColors() {
+    let accuracy: CGFloat = 0.001
+    let bundle = NSBundle(forClass: self.classForCoder)
+    let path = bundle.pathForResource("Random Access Memories", ofType: "png")!
+    let image = NSImage(contentsOfFile: path)!
+
+    XCTAssertNotNil(image)
+
+    let colors = image.colors()
+    
+    var (red, green, blue): (CGFloat, CGFloat, CGFloat) = (0,0,0)
+    
+    colors.background.getRed(&red, green: &green, blue: &blue, alpha: nil)
+
+    XCTAssertEqualWithAccuracy(red, 0.035, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(green, 0.05, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(blue, 0.054, accuracy: accuracy)
+
+    colors.primary.getRed(&red, green: &green, blue: &blue, alpha: nil)
+
+    XCTAssertEqualWithAccuracy(red, 0.563, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(green, 0.572, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(blue, 0.662, accuracy: accuracy)
+
+    colors.secondary.getRed(&red, green: &green, blue: &blue, alpha: nil)
+
+    XCTAssertEqualWithAccuracy(red, 0.746, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(green, 0.831, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(blue, 0.878, accuracy: accuracy)
+
+    colors.detail.getRed(&red, green: &green, blue: &blue, alpha: nil)
+
+    XCTAssertEqualWithAccuracy(red, 1.000, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(green, 1.000, accuracy: accuracy)
+    XCTAssertEqualWithAccuracy(blue, 0.85, accuracy: accuracy)
+  }
+
+}

--- a/Source/Mac/NSColor+Hue.swift
+++ b/Source/Mac/NSColor+Hue.swift
@@ -1,0 +1,110 @@
+import AppKit
+
+// MARK: - Color Builders
+
+public extension NSColor {
+
+  public static func hex(string: String) -> NSColor {
+    var hex = string.hasPrefix("#")
+      ? String(string.characters.dropFirst())
+      : string
+
+    guard hex.characters.count == 3 || hex.characters.count == 6
+      else { return NSColor.whiteColor().colorWithAlphaComponent(0.0) }
+
+    if hex.characters.count == 3 {
+      for (index, char) in hex.characters.enumerate() {
+        hex.insert(char, atIndex: hex.startIndex.advancedBy(index * 2))
+      }
+    }
+
+    return NSColor(
+      red:   CGFloat((Int(hex, radix: 16)! >> 16) & 0xFF),
+      green: CGFloat((Int(hex, radix: 16)! >> 8) & 0xFF),
+      blue:  CGFloat((Int(hex, radix: 16)!) & 0xFF), alpha: 1.0)
+  }
+
+  public func colorWithMinimumSaturation(minSaturation: CGFloat) -> NSColor {
+    var (hue, saturation, brightness, alpha): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
+    getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+
+    return saturation < minSaturation
+      ? NSColor(hue: hue, saturation: minSaturation, brightness: brightness, alpha: alpha)
+      : self
+  }
+
+  public func alpha(value: CGFloat) -> NSColor {
+    return colorWithAlphaComponent(value)
+  }
+}
+
+// MARK: - Helpers
+
+public extension NSColor {
+
+  public func hex(withPrefix withPrefix: Bool = true) -> String {
+    var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
+    colorUsingColorSpace(NSColorSpace.genericRGBColorSpace())!.getRed(&r, green: &g, blue: &b, alpha: &a)
+
+    let prefix = withPrefix ? "#" : ""
+
+    return String(format: "\(prefix)%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
+  }
+
+  public var isDark: Bool {
+    let RGB = CGColorGetComponents(CGColor)
+    return (0.2126 * RGB[0] + 0.7152 * RGB[1] + 0.0722 * RGB[2]) < 0.5
+  }
+
+  public var isBlackOrWhite: Bool {
+    let RGB = CGColorGetComponents(CGColor)
+    return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91) || (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
+  }
+
+  public func isDistinctFrom(color: NSColor) -> Bool {
+    let bg = CGColorGetComponents(CGColor)
+    let fg = CGColorGetComponents(color.CGColor)
+    let threshold: CGFloat = 0.25
+    var result = false
+
+    if fabs(bg[0] - fg[0]) > threshold || fabs(bg[1] - fg[1]) > threshold || fabs(bg[2] - fg[2]) > threshold {
+      if fabs(bg[0] - bg[1]) < 0.03 && fabs(bg[0] - bg[2]) < 0.03 {
+        if fabs(fg[0] - fg[1]) < 0.03 && fabs(fg[0] - fg[2]) < 0.03 {
+          result = false
+        }
+      }
+      result = true
+    }
+
+    return result
+  }
+
+  public func isContrastingWith(color: NSColor) -> Bool {
+    let bg = CGColorGetComponents(CGColor)
+    let fg = CGColorGetComponents(color.CGColor)
+
+    let bgLum = 0.2126 * bg[0] + 0.7152 * bg[1] + 0.0722 * bg[2]
+    let fgLum = 0.2126 * fg[0] + 0.7152 * fg[1] + 0.0722 * fg[2]
+    let contrast = bgLum > fgLum
+      ? (bgLum + 0.05) / (fgLum + 0.05)
+      : (fgLum + 0.05) / (bgLum + 0.05)
+
+    return 1.6 < contrast
+  }
+}
+
+// MARK: - Gradient
+
+public extension Array where Element : NSColor {
+
+  public func gradient(transform: ((inout gradient: CAGradientLayer) -> CAGradientLayer)? = nil) -> CAGradientLayer {
+    var gradient = CAGradientLayer()
+    gradient.colors = self.map { $0.CGColor }
+
+    if let transform = transform {
+      transform(gradient: &gradient)
+    }
+
+    return gradient
+  }
+}

--- a/Source/Mac/NSImage+Hue.swift
+++ b/Source/Mac/NSImage+Hue.swift
@@ -1,0 +1,153 @@
+import AppKit
+
+class CountedColor {
+  let color: NSColor
+  let count: Int
+
+  init(color: NSColor, count: Int) {
+    self.color = color
+    self.count = count
+  }
+}
+
+extension NSImage {
+
+  private func resize(newSize: CGSize) -> NSImage {
+    let scaledImage = NSImage(size: newSize)
+    scaledImage.lockFocus()
+    let ctx = NSGraphicsContext.currentContext()
+    ctx?.imageInterpolation = .High
+    drawInRect(NSMakeRect(0, 0, newSize.width, newSize.height), fromRect: NSRect.zero, operation: .CompositeCopy, fraction: 1)
+    scaledImage.unlockFocus()
+    
+    return scaledImage
+  }
+
+  public func colors(scaleDownSize: CGSize? = nil) -> (background: NSColor, primary: NSColor, secondary: NSColor, detail: NSColor) {
+    let cgImage: CGImageRef
+
+    if let scaleDownSize = scaleDownSize {
+      let context = NSGraphicsContext.currentContext()
+      cgImage = resize(scaleDownSize).CGImageForProposedRect(nil, context: context, hints: nil)!
+    } else {
+      let context = NSGraphicsContext.currentContext()
+      let ratio = size.width / size.height
+      let r_width: CGFloat = 250
+      cgImage = resize(CGSize(width: r_width, height: r_width / ratio)).CGImageForProposedRect(nil, context: context, hints: nil)!
+    }
+
+    let width = CGImageGetWidth(cgImage)
+    let height = CGImageGetHeight(cgImage)
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    let bitsPerComponent = 8
+    let randomColorsThreshold = Int(CGFloat(height) * 0.01)
+    let blackColor = NSColor(red: 0, green: 0, blue: 0, alpha: 1)
+    let whiteColor = NSColor(red: 1, green: 1, blue: 1, alpha: 1)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let raw = malloc(bytesPerRow * height)
+    let bitmapInfo = CGImageAlphaInfo.PremultipliedFirst.rawValue
+    let context = CGBitmapContextCreate(raw, width, height, bitsPerComponent, bytesPerRow, colorSpace, bitmapInfo)
+    CGContextDrawImage(context, CGRectMake(0, 0, CGFloat(width), CGFloat(height)), cgImage)
+    let data = UnsafePointer<UInt8>(CGBitmapContextGetData(context))
+    let imageBackgroundColors = NSCountedSet(capacity: height)
+    let imageColors = NSCountedSet(capacity: width * height)
+
+    let sortComparator: (CountedColor, CountedColor) -> Bool = { (a, b) -> Bool in
+      return a.count <= b.count
+    }
+
+    for x in 0..<width {
+      for y in 0..<height {
+        let pixel = ((width * y) + x) * bytesPerPixel
+        let color = NSColor(
+          red:   CGFloat(data[pixel+1]) / 255,
+          green: CGFloat(data[pixel+2]) / 255,
+          blue:  CGFloat(data[pixel+3]) / 255,
+          alpha: 1
+        )
+
+        if x >= 5 && x <= 10 {
+          imageBackgroundColors.addObject(color)
+        }
+
+        imageColors.addObject(color)
+      }
+    }
+    
+    var sortedColors = [CountedColor]()
+
+    for color in imageBackgroundColors {
+      guard let color = color as? NSColor else { continue }
+
+      let colorCount = imageBackgroundColors.countForObject(color)
+
+      if randomColorsThreshold <= colorCount  {
+        sortedColors.append(CountedColor(color: color, count: colorCount))
+      }
+    }
+
+    sortedColors.sortInPlace(sortComparator)
+
+    var proposedEdgeColor = CountedColor(color: blackColor, count: 1)
+
+    if let first = sortedColors.first { proposedEdgeColor = first }
+
+    if proposedEdgeColor.color.isBlackOrWhite && !sortedColors.isEmpty {
+      for countedColor in sortedColors where CGFloat(countedColor.count / proposedEdgeColor.count) > 0.3 {
+        if !countedColor.color.isBlackOrWhite {
+          proposedEdgeColor = countedColor
+          break
+        }
+      }
+    }
+
+    let imageBackgroundColor = proposedEdgeColor.color
+    let isDarkBackgound = imageBackgroundColor.isDark
+
+    sortedColors.removeAll()
+
+    for imageColor in imageColors {
+      guard let imageColor = imageColor as? NSColor else { continue }
+
+      let color = imageColor.colorWithMinimumSaturation(0.15)
+
+      if color.isDark == !isDarkBackgound {
+        let colorCount = imageColors.countForObject(color)
+        sortedColors.append(CountedColor(color: color, count: colorCount))
+      }
+    }
+
+    sortedColors.sortInPlace(sortComparator)
+
+    var primaryColor, secondaryColor, detailColor: NSColor?
+
+    for countedColor in sortedColors {
+      let color = countedColor.color
+
+      if primaryColor == nil &&
+        color.isContrastingWith(imageBackgroundColor) {
+          primaryColor = color
+      } else if secondaryColor == nil &&
+        primaryColor != nil &&
+        primaryColor!.isDistinctFrom(color) &&
+        color.isContrastingWith(imageBackgroundColor) {
+          secondaryColor = color
+      } else if secondaryColor != nil &&
+        (secondaryColor!.isDistinctFrom(color) &&
+          primaryColor!.isDistinctFrom(color) &&
+          color.isContrastingWith(imageBackgroundColor)) {
+            detailColor = color
+            break
+      }
+    }
+
+    free(raw)
+
+    return (
+      imageBackgroundColor,
+      primaryColor   ?? (isDarkBackgound ? whiteColor : blackColor),
+      secondaryColor ?? (isDarkBackgound ? whiteColor : blackColor),
+      detailColor    ?? (isDarkBackgound ? whiteColor : blackColor))
+  }
+}


### PR DESCRIPTION
This version passes the NS version of the UIColorTests. However, it fails the NS version of the UIImageTests. This is possibly due to the size of the analysed image being different to the iOS version (see #5). I played around with some ideas but couldn't get the tests to pass so figured I'd enlist some help or advice through a pull request. The returned background, primary, secondary and detail colours are not far from the iOS versions but not close enough to pass the tests.
