### PR TITLE
Remove "linking against dylib not safe for use in application extensions" warning

### DIFF
--- a/Hue.xcodeproj/project.pbxproj
+++ b/Hue.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 		386887A21C8343D0005A8868 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -450,6 +451,7 @@
 		386887A31C8343D0005A8868 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -592,6 +594,7 @@
 		D52862271C3EAC1D00AD11AD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -609,6 +612,7 @@
 		D52862281C3EAC1D00AD11AD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
Remove ["linking against dylib not safe for use in application extensions" warning](https://developer.apple.com/library/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html) when the application project that includes app extension is integrated with Hue.framework using Carthage

The warning message in Report navigator is: 

```
Ld /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Products/Debug-iphonesimulator/FooExtension.appex/FooExtension normal x86_64
    cd /path/to/mine/works/Foo-ios
    export IPHONEOS_DEPLOYMENT_TARGET=9.0
    export PATH="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin:/Applications/Xcode.app/Contents/Developer/usr/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.3.sdk -L/path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Products/Debug-iphonesimulator -F/path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Products/Debug-iphonesimulator -F/path/to/mine/works/Foo-ios/Carthage/Build/iOS -filelist /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Intermediates/Foo.build/Debug-iphonesimulator/FooExtension.build/Objects-normal/x86_64/FooExtension.LinkFileList -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @loader_path/Frameworks -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @executable_path/../../Frameworks -mios-simulator-version-min=9.0 -Xlinker -no_deduplicate -Xlinker -objc_abi_version -Xlinker 2 -framework SDWebImage -e _NSExtensionMain -fapplication-extension -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator -Xlinker -add_ast_path -Xlinker /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Intermediates/Foo.build/Debug-iphonesimulator/FooExtension.build/Objects-normal/x86_64/FooExtension.swiftmodule -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __entitlements -Xlinker /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Intermediates/Foo.build/Debug-iphonesimulator/FooExtension.build/FooExtension.appex.xcent -framework Hue -framework CollectionViewWaterfallLayout -framework HTTPStatusCodes -framework RxCocoa -framework RxSwift -framework Security -framework KeychainAccess -framework SwiftyJSON -framework Alamofire -framework Pods_FooExtension -Xlinker -dependency_info -Xlinker /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Intermediates/Foo.build/Debug-iphonesimulator/FooExtension.build/Objects-normal/x86_64/FooExtension_dependency_info.dat -o /path/to/mine/Library/Developer/Xcode/DerivedData/Foo-brbdrhsipbngmbecsynuwcvgwsgt/Build/Products/Debug-iphonesimulator/FooExtension.appex/FooExtension

ld: warning: linking against a dylib which is not safe for use in application extensions: /path/to/mine/works/Foo-ios/Carthage/Build/iOS/Hue.framework/Hue
```
