### PR TITLE
Fix/hex init

### DIFF
--- a/Example/Gradients/Gradients.xcodeproj/project.pbxproj
+++ b/Example/Gradients/Gradients.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B0B630FF9E74EDC679D59AF /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA6288E56E8D691786FA2D88 /* Pods.framework */; };
+		9CA35711A22687097445773A /* Pods_Gradients.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB7F514B38C790EF45452227 /* Pods_Gradients.framework */; };
 		BDD79C131C33E3E3004828C1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD79C0C1C33E3E3004828C1 /* AppDelegate.swift */; };
 		BDD79C141C33E3E3004828C1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDD79C0D1C33E3E3004828C1 /* Assets.xcassets */; };
 		BDD79C151C33E3E3004828C1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BDD79C0E1C33E3E3004828C1 /* LaunchScreen.storyboard */; };
@@ -18,8 +18,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		4F63E22D48084732C25112B7 /* Pods-Gradients.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Gradients.release.xcconfig"; path = "Pods/Target Support Files/Pods-Gradients/Pods-Gradients.release.xcconfig"; sourceTree = "<group>"; };
+		BB7F514B38C790EF45452227 /* Pods_Gradients.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Gradients.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDD79C0C1C33E3E3004828C1 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BDD79C0D1C33E3E3004828C1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BDD79C0F1C33E3E3004828C1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -30,6 +30,7 @@
 		BDD79C1E1C33F642004828C1 /* Font.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		BDDDF1701C32B5930087F872 /* Gradients.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gradients.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA6288E56E8D691786FA2D88 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E15E1F0C20EA3B194AA7BC08 /* Pods-Gradients.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Gradients.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Gradients/Pods-Gradients.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,17 +38,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B0B630FF9E74EDC679D59AF /* Pods.framework in Frameworks */,
+				9CA35711A22687097445773A /* Pods_Gradients.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		165CFEB136762DFF3FF22DD0 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				E15E1F0C20EA3B194AA7BC08 /* Pods-Gradients.debug.xcconfig */,
+				4F63E22D48084732C25112B7 /* Pods-Gradients.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		1C267CDA71C06E96EF89E1D1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				CA6288E56E8D691786FA2D88 /* Pods.framework */,
+				BB7F514B38C790EF45452227 /* Pods_Gradients.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -80,8 +91,8 @@
 			children = (
 				BDD79C0B1C33E3E3004828C1 /* Gradients */,
 				BDDDF1711C32B5930087F872 /* Products */,
-				C41F313752B6F01D614EB5F8 /* Pods */,
 				1C267CDA71C06E96EF89E1D1 /* Frameworks */,
+				165CFEB136762DFF3FF22DD0 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -93,15 +104,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		C41F313752B6F01D614EB5F8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */,
-				9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -109,12 +111,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BDDDF1821C32B5930087F872 /* Build configuration list for PBXNativeTarget "Gradients" */;
 			buildPhases = (
-				F4CA0BAB0AA23D40D700CC59 /* Check Pods Manifest.lock */,
+				E82B9BC35D0C7A652506E34B /* [CP] Check Pods Manifest.lock */,
 				BDDDF16C1C32B5930087F872 /* Sources */,
 				BDDDF16D1C32B5930087F872 /* Frameworks */,
 				BDDDF16E1C32B5930087F872 /* Resources */,
-				434F9D4713E48F75706D2D76 /* Embed Pods Frameworks */,
-				BEAC7D033C027EFCE5D6EF3C /* Copy Pods Resources */,
+				8A1E04B668EBCA504AF5ED73 /* [CP] Embed Pods Frameworks */,
+				DB64041712723E32081F3048 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -171,44 +173,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		434F9D4713E48F75706D2D76 /* Embed Pods Frameworks */ = {
+		8A1E04B668EBCA504AF5ED73 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Gradients/Pods-Gradients-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEAC7D033C027EFCE5D6EF3C /* Copy Pods Resources */ = {
+		DB64041712723E32081F3048 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Gradients/Pods-Gradients-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F4CA0BAB0AA23D40D700CC59 /* Check Pods Manifest.lock */ = {
+		E82B9BC35D0C7A652506E34B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,7 +330,7 @@
 		};
 		BDDDF1831C32B5930087F872 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = E15E1F0C20EA3B194AA7BC08 /* Pods-Gradients.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Gradients/Info.plist";
@@ -340,7 +342,7 @@
 		};
 		BDDDF1841C32B5930087F872 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */;
+			baseConfigurationReference = 4F63E22D48084732C25112B7 /* Pods-Gradients.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "$(SRCROOT)/Gradients/Info.plist";

--- a/Example/Gradients/Gradients/Cells/GradientListCell.swift
+++ b/Example/Gradients/Gradients/Cells/GradientListCell.swift
@@ -12,7 +12,7 @@ class GradientListCell: ListSpotCell {
   }()
 
   override func configure(inout item: ViewModel) {
-    textLabel?.textColor = UIColor.hex("#fff").alpha(0.8)
+    textLabel?.textColor = UIColor(hex:"#fff").alpha(0.8)
     textLabel?.text = item.title
     textLabel?.font = Font.cell
     selectedBackgroundView = selectedView

--- a/Example/Gradients/Gradients/GradientsController.swift
+++ b/Example/Gradients/Gradients/GradientsController.swift
@@ -8,8 +8,8 @@ class GradientsController: SpotsController {
   static let faker = Faker()
 
   lazy var gradient: CAGradientLayer = [
-    UIColor.hex("#FD4340"),
-    UIColor.hex("#CE2BAE")
+    UIColor(hex:"#FD4340"),
+    UIColor(hex:"#CE2BAE")
     ].gradient { gradient in
       gradient.speed = 0
       gradient.timeOffset = 0
@@ -31,8 +31,8 @@ class GradientsController: SpotsController {
 
     animation.fromValue = gradient.colors
     animation.toValue = [
-      UIColor.hex("#8D24FF").CGColor,
-      UIColor.hex("#23A8F9").CGColor
+      UIColor(hex:"#8D24FF").CGColor,
+      UIColor(hex:"#23A8F9").CGColor
     ]
   }
 

--- a/Example/Gradients/Podfile
+++ b/Example/Gradients/Podfile
@@ -5,6 +5,8 @@ platform :ios, '8.0'
 use_frameworks!
 inhibit_all_warnings!
 
+target 'Gradients'
+
 pod 'Hue', path: '../../'
 pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary'
 pod 'Cache', git: 'https://github.com/hyperoslo/Cache'

--- a/Example/Gradients/Podfile.lock
+++ b/Example/Gradients/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Cache (1.0.0)
   - Fakery (1.1.1):
     - SwiftyJSON
-  - Hue (1.0.0)
+  - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
   - Spots (1.0.0):
@@ -51,11 +51,13 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Cache: 78f58bc008313c7a1182967a2ebcb3de9fddecd4
   Fakery: a159ad2f48e01c5ae7059c201700b38fa0484707
-  Hue: 44ae8b1091935fcc75055174095ab04653989235
+  Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
   Spots: 0e2a783d37cf05ce0752e2ae4cd709de0112cb04
   Sugar: 0dec8fa53840c88c01579e61bcff8edbe468cb41
   SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
   Tailor: 3ec670165a4a0b728c187313e85b433af457152c
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: bb3722b747ee2ca0f533f2edc06801a2315a6c96
+
+COCOAPODS: 1.0.1

--- a/Example/Hex/Hex.xcodeproj/project.pbxproj
+++ b/Example/Hex/Hex.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3B0B630FF9E74EDC679D59AF /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA6288E56E8D691786FA2D88 /* Pods.framework */; };
+		A1ADEBDF3AE5C6A3D73EA28B /* Pods_Hex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 570EABBFB2AAE80045AC0D16 /* Pods_Hex.framework */; };
 		BDDDF1741C32B5930087F872 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDDDF1731C32B5930087F872 /* AppDelegate.swift */; };
 		BDDDF17B1C32B5930087F872 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BDDDF17A1C32B5930087F872 /* Assets.xcassets */; };
 		BDDDF17E1C32B5930087F872 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BDDDF17C1C32B5930087F872 /* LaunchScreen.storyboard */; };
@@ -15,8 +15,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
-		A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		07F6F7E76E74F4569FD62276 /* Pods-Hex.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hex.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Hex/Pods-Hex.debug.xcconfig"; sourceTree = "<group>"; };
+		570EABBFB2AAE80045AC0D16 /* Pods_Hex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B1A724969C68F816EA5E95EB /* Pods-Hex.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hex.release.xcconfig"; path = "Pods/Target Support Files/Pods-Hex/Pods-Hex.release.xcconfig"; sourceTree = "<group>"; };
 		BDDDF1701C32B5930087F872 /* Hex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDDDF1731C32B5930087F872 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BDDDF17A1C32B5930087F872 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -31,7 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3B0B630FF9E74EDC679D59AF /* Pods.framework in Frameworks */,
+				A1ADEBDF3AE5C6A3D73EA28B /* Pods_Hex.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -42,8 +43,18 @@
 			isa = PBXGroup;
 			children = (
 				CA6288E56E8D691786FA2D88 /* Pods.framework */,
+				570EABBFB2AAE80045AC0D16 /* Pods_Hex.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		514099224540B1098772FC44 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				07F6F7E76E74F4569FD62276 /* Pods-Hex.debug.xcconfig */,
+				B1A724969C68F816EA5E95EB /* Pods-Hex.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 		BDDDF1671C32B5930087F872 = {
@@ -51,8 +62,8 @@
 			children = (
 				BDDDF1721C32B5930087F872 /* Hex */,
 				BDDDF1711C32B5930087F872 /* Products */,
-				C41F313752B6F01D614EB5F8 /* Pods */,
 				1C267CDA71C06E96EF89E1D1 /* Frameworks */,
+				514099224540B1098772FC44 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -84,15 +95,6 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
-		C41F313752B6F01D614EB5F8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */,
-				9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -100,12 +102,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BDDDF1821C32B5930087F872 /* Build configuration list for PBXNativeTarget "Hex" */;
 			buildPhases = (
-				F4CA0BAB0AA23D40D700CC59 /* Check Pods Manifest.lock */,
+				A317C1E0E6B9B692D585CCA3 /* [CP] Check Pods Manifest.lock */,
 				BDDDF16C1C32B5930087F872 /* Sources */,
 				BDDDF16D1C32B5930087F872 /* Frameworks */,
 				BDDDF16E1C32B5930087F872 /* Resources */,
-				434F9D4713E48F75706D2D76 /* Embed Pods Frameworks */,
-				BEAC7D033C027EFCE5D6EF3C /* Copy Pods Resources */,
+				6CF9CD6F35647C5715A733B5 /* [CP] Embed Pods Frameworks */,
+				D022F31BB0500FAF08D24396 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -162,49 +164,49 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		434F9D4713E48F75706D2D76 /* Embed Pods Frameworks */ = {
+		6CF9CD6F35647C5715A733B5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hex/Pods-Hex-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BEAC7D033C027EFCE5D6EF3C /* Copy Pods Resources */ = {
+		A317C1E0E6B9B692D585CCA3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F4CA0BAB0AA23D40D700CC59 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		D022F31BB0500FAF08D24396 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Hex/Pods-Hex-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -316,7 +318,7 @@
 		};
 		BDDDF1831C32B5930087F872 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A98837528CBB518D9D869F03 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 07F6F7E76E74F4569FD62276 /* Pods-Hex.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Hex/Info.plist;
@@ -328,7 +330,7 @@
 		};
 		BDDDF1841C32B5930087F872 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9EC638BABDD22702FC2CA5BA /* Pods.release.xcconfig */;
+			baseConfigurationReference = B1A724969C68F816EA5E95EB /* Pods-Hex.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Hex/Info.plist;

--- a/Example/Hex/Hex/Cells/GridHexCell.swift
+++ b/Example/Hex/Hex/Cells/GridHexCell.swift
@@ -26,7 +26,7 @@ class GridHexCell: UICollectionViewCell, ViewConfigurable {
   }
 
   func configure(inout item: ViewModel) {
-    let color = UIColor.hex(item.title)
+    let color = UIColor(hex:item.title)
     backgroundColor = color
 
     label.textColor = color.isDark ? UIColor.whiteColor() : UIColor.darkGrayColor()

--- a/Example/Hex/Podfile
+++ b/Example/Hex/Podfile
@@ -5,6 +5,8 @@ platform :ios, '8.0'
 use_frameworks!
 inhibit_all_warnings!
 
+target 'Hex'
+
 pod 'Hue', path: '../../'
 pod 'Imaginary', git: 'https://github.com/hyperoslo/Imaginary'
 pod 'Cache', git: 'https://github.com/hyperoslo/Cache'

--- a/Example/Hex/Podfile.lock
+++ b/Example/Hex/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Cache (1.0.0)
-  - Hue (1.0.0)
+  - Hue (1.1.1)
   - Imaginary (0.1.0):
     - Cache
   - Spots (1.0.0):
@@ -46,10 +46,12 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Cache: 78f58bc008313c7a1182967a2ebcb3de9fddecd4
-  Hue: 44ae8b1091935fcc75055174095ab04653989235
+  Hue: 931aeeadcb29ce5de5b97589aa936be4638a1501
   Imaginary: feaea646440c68a9b6ed66a46597d548b9a44207
   Spots: 0e2a783d37cf05ce0752e2ae4cd709de0112cb04
   Sugar: 0dec8fa53840c88c01579e61bcff8edbe468cb41
   Tailor: 3ec670165a4a0b728c187313e85b433af457152c
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: 171999a07f2a9e6340cb692e4156f27b64748adc
+
+COCOAPODS: 1.0.1

--- a/Source/Mac/NSColor+Hue.swift
+++ b/Source/Mac/NSColor+Hue.swift
@@ -4,13 +4,16 @@ import AppKit
 
 public extension NSColor {
 
-  public static func hex(string: String) -> NSColor {
-    var hex = string.hasPrefix("#")
-      ? String(string.characters.dropFirst())
-      : string
+  convenience init(hex: String) {
+    var hex = hex.hasPrefix("#")
+      ? String(hex.characters.dropFirst())
+      : hex
 
     guard hex.characters.count == 3 || hex.characters.count == 6
-      else { return NSColor.whiteColor().colorWithAlphaComponent(0.0) }
+      else {
+        self.init(white: 1.0, alpha: 0.0)
+        return
+    }
 
     if hex.characters.count == 3 {
       for (index, char) in hex.characters.enumerate() {
@@ -18,10 +21,15 @@ public extension NSColor {
       }
     }
 
-    return NSColor(
+    self.init(
       red:   CGFloat((Int(hex, radix: 16)! >> 16) & 0xFF) / 255.0,
       green: CGFloat((Int(hex, radix: 16)! >> 8) & 0xFF) / 255.0,
       blue:  CGFloat((Int(hex, radix: 16)!) & 0xFF) / 255.0, alpha: 1.0)
+  }
+
+  @available(*, deprecated=1.1.2)
+  public static func hex(string: String) -> NSColor {
+    return NSColor(hex: string)
   }
 
   public func colorWithMinimumSaturation(minSaturation: CGFloat) -> NSColor {

--- a/Source/iOS/UIColor+Hue.swift
+++ b/Source/iOS/UIColor+Hue.swift
@@ -4,13 +4,16 @@ import UIKit
 
 public extension UIColor {
 
-  public static func hex(string: String) -> UIColor {
+  convenience init(hex string: String) {
     var hex = string.hasPrefix("#")
       ? String(string.characters.dropFirst())
       : string
 
     guard hex.characters.count == 3 || hex.characters.count == 6
-      else { return UIColor.whiteColor().colorWithAlphaComponent(0.0) }
+      else {
+        self.init(white: 1.0, alpha: 0.0)
+        return
+    }
 
     if hex.characters.count == 3 {
       for (index, char) in hex.characters.enumerate() {
@@ -18,10 +21,15 @@ public extension UIColor {
       }
     }
 
-    return UIColor(
+    self.init(
       red:   CGFloat((Int(hex, radix: 16)! >> 16) & 0xFF) / 255.0,
       green: CGFloat((Int(hex, radix: 16)! >> 8) & 0xFF) / 255.0,
       blue:  CGFloat((Int(hex, radix: 16)!) & 0xFF) / 255.0, alpha: 1.0)
+  }
+
+  @available(*, deprecated=1.1.2)
+  public static func hex(string: String) -> UIColor {
+    return UIColor(hex: string)
   }
 
   public func colorWithMinimumSaturation(minSaturation: CGFloat) -> UIColor {
@@ -60,12 +68,12 @@ public extension UIColor {
     let RGB = CGColorGetComponents(CGColor)
     return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91) || (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
   }
-    
+
   public var isBlack: Bool {
     let RGB = CGColorGetComponents(CGColor)
     return (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
   }
-    
+
   public var isWhite: Bool {
     let RGB = CGColorGetComponents(CGColor)
     return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91)
@@ -101,7 +109,7 @@ public extension UIColor {
 
     return 1.6 < contrast
   }
-    
+
 }
 
 // MARK: - Gradient
@@ -123,7 +131,7 @@ public extension Array where Element : UIColor {
 // MARK: - Components
 
 public extension UIColor {
-    
+
   var redComponent : CGFloat {
     get {
       var r : CGFloat = 0
@@ -131,7 +139,7 @@ public extension UIColor {
       return r
     }
   }
-  
+
   var greenComponent : CGFloat {
     get {
       var g : CGFloat = 0
@@ -139,7 +147,7 @@ public extension UIColor {
       return g
     }
   }
-  
+
   var blueComponent : CGFloat {
     get {
       var b : CGFloat = 0
@@ -147,7 +155,7 @@ public extension UIColor {
       return b
     }
   }
-  
+
   var alphaComponent : CGFloat {
     get {
       var a : CGFloat = 0
@@ -161,37 +169,37 @@ public extension UIColor {
 // MARK: - Blending
 
 public extension UIColor {
-  
+
   /**adds hue, saturation, and brightness to the HSB components of this color (self)*/
   public func addHue(hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) -> UIColor {
     var (oldHue, oldSat, oldBright, oldAlpha) : (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
     self.getHue(&oldHue, saturation: &oldSat, brightness: &oldBright, alpha: &oldAlpha)
     return UIColor(hue: oldHue + hue, saturation: oldSat + saturation, brightness: oldBright + brightness, alpha: oldAlpha + alpha)
   }
-  
+
   /**adds red, green, and blue to the RGB components of this color (self)*/
   public func addRed(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> UIColor {
     var (oldRed, oldGreen, oldBlue, oldAlpha) : (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
     self.getRed(&oldRed, green: &oldGreen, blue: &oldBlue, alpha: &oldAlpha)
     return UIColor(red: oldRed + red, green: oldGreen + green, blue: oldBlue + blue, alpha: oldAlpha + alpha)
   }
-  
+
   public func addHSB(color: UIColor) -> UIColor {
     var (h,s,b,a) : (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
     color.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
     return self.addHue(h, saturation: s, brightness: b, alpha: 0)
   }
-  
+
   public func addRGB(color: UIColor) -> UIColor {
     return self.addRed(color.redComponent, green: color.greenComponent, blue: color.blueComponent, alpha: 0)
   }
-    
+
   public func addHSBA(color: UIColor) -> UIColor {
     var (h,s,b,a) : (CGFloat, CGFloat, CGFloat, CGFloat) = (0,0,0,0)
     color.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
     return self.addHue(h, saturation: s, brightness: b, alpha: a)
   }
-  
+
   /**adds the rgb components of two colors*/
   public func addRGBA(color: UIColor) -> UIColor {
     return self.addRed(color.redComponent, green: color.greenComponent, blue: color.blueComponent, alpha: color.alphaComponent)


### PR DESCRIPTION
This PR refactors the static `.hex()` method into `init(hex:_)`.

Why? Well, to me (and others 😎), it makes more sense for it to be an initializer than a `static` method returning a color based on the `hex` that you pass it.

So instead of;

``` swift
let color = UIColor.hex("#ff0")
```

You’ll do;

``` swift
let color = UIColor(hex:"#ff0")
```

The old method is still there in this version but it is marked as deprecated.
