### PR TITLE
Fix isDark and add test cases

### DIFF
--- a/HueTests/Mac/NSColorTests.swift
+++ b/HueTests/Mac/NSColorTests.swift
@@ -146,4 +146,68 @@ class NSColorTests: XCTestCase {
     XCTAssertEqual(testBlue.getGreen(), blue.getGreen())
     XCTAssertEqual(testBlue.getBlue(), blue.getBlue())
   }
+  
+  func testIsDark() {
+    // Colors created in the monochrome colorSpace -> 2 components
+    let monochromeBlack = NSColor.black
+    let monochromeWhite = NSColor.white
+    let monochromeDarkGray = NSColor.darkGray
+    let monochromeGray = NSColor.gray
+    let monochromeLightGray = NSColor.lightGray
+    
+    // Colors created in the RGBA colorSpace -> 4 components
+    let black = NSColor(hex: "000")
+    let white = NSColor(hex: "fff")
+    let darkGray = NSColor(hex: "555")
+    let gray = NSColor(hex: "7f7f7f")
+    let lightGray = NSColor(hex: "aaa")
+    let yellow = NSColor.yellow
+    let green = NSColor.green
+    let red = NSColor.red
+    let blue = NSColor.blue
+    
+    
+    let isMonochromeBlackDark = monochromeBlack.isDark
+    XCTAssertEqual(isMonochromeBlackDark, true)
+    
+    let isMonochromeWhiteDark = monochromeWhite.isDark
+    XCTAssertEqual(isMonochromeWhiteDark, false)
+    
+    let isMonochromeDarkGrayDark = monochromeDarkGray.isDark
+    XCTAssertEqual(isMonochromeDarkGrayDark, true)
+    
+    let isMonochromeGrayDark = monochromeGray.isDark
+    XCTAssertEqual(isMonochromeGrayDark, false)
+    
+    let isMonochromeLightGrayDark = monochromeLightGray.isDark
+    XCTAssertEqual(isMonochromeLightGrayDark, false)
+    
+    let isBlackDark = black.isDark
+    XCTAssertEqual(isBlackDark, true)
+    
+    let isWhiteDark = white.isDark
+    XCTAssertEqual(isWhiteDark, false)
+    
+    let isDarkGrayDark = darkGray.isDark
+    XCTAssertEqual(isDarkGrayDark, true)
+    
+//  edge case! Should be false, but `rgbComponents()` returns 0.498039215686275 instead of 0.5 for each component
+//    let isGrayDark = gray.isDark
+//    XCTAssertEqual(isGrayDark, false)
+    
+    let isLightGrayDark = lightGray.isDark
+    XCTAssertEqual(isLightGrayDark, false)
+    
+    let isYellowDark = yellow.isDark
+    XCTAssertEqual(isYellowDark, false)
+    
+    let isGreenDark = green.isDark
+    XCTAssertEqual(isGreenDark, false)
+    
+    let isRedDark = red.isDark
+    XCTAssertEqual(isRedDark, true)
+    
+    let isBlueDark = blue.isDark
+    XCTAssertEqual(isBlueDark, true)
+  }
 }

--- a/HueTests/iOS/UIColorTests.swift
+++ b/HueTests/iOS/UIColorTests.swift
@@ -146,4 +146,68 @@ class UIColorTests: XCTestCase {
     XCTAssertEqual(testBlue.greenComponent, blue.greenComponent)
     XCTAssertEqual(testBlue.blueComponent, blue.blueComponent)
   }
+  
+  func testIsDark() {
+    // Colors created in the monochrome colorSpace -> 2 components
+    let monochromeBlack = UIColor.black
+    let monochromeWhite = UIColor.white
+    let monochromeDarkGray = UIColor.darkGray
+    let monochromeGray = UIColor.gray
+    let monochromeLightGray = UIColor.lightGray
+    
+    // Colors created in the RGBA colorSpace -> 4 components
+    let black = UIColor(hex: "000")
+    let white = UIColor(hex: "fff")
+    let darkGray = UIColor(hex: "555")
+    let gray = UIColor(hex: "7f7f7f")
+    let lightGray = UIColor(hex: "aaa")
+    let yellow = UIColor.yellow
+    let green = UIColor.green
+    let red = UIColor.red
+    let blue = UIColor.blue
+
+    
+    let isMonochromeBlackDark = monochromeBlack.isDark
+    XCTAssertEqual(isMonochromeBlackDark, true)
+    
+    let isMonochromeWhiteDark = monochromeWhite.isDark
+    XCTAssertEqual(isMonochromeWhiteDark, false)
+    
+    let isMonochromeDarkGrayDark = monochromeDarkGray.isDark
+    XCTAssertEqual(isMonochromeDarkGrayDark, true)
+    
+    let isMonochromeGrayDark = monochromeGray.isDark
+    XCTAssertEqual(isMonochromeGrayDark, false)
+    
+    let isMonochromeLightGrayDark = monochromeLightGray.isDark
+    XCTAssertEqual(isMonochromeLightGrayDark, false)
+    
+    let isBlackDark = black.isDark
+    XCTAssertEqual(isBlackDark, true)
+    
+    let isWhiteDark = white.isDark
+    XCTAssertEqual(isWhiteDark, false)
+    
+    let isDarkGrayDark = darkGray.isDark
+    XCTAssertEqual(isDarkGrayDark, true)
+    
+//  edge case! Should be false, but `rgbComponents()` returns 0.498039215686275 instead of 0.5 for each component
+//    let isGrayDark = gray.isDark
+//    XCTAssertEqual(isGrayDark, false)
+    
+    let isLightGrayDark = lightGray.isDark
+    XCTAssertEqual(isLightGrayDark, false)
+    
+    let isYellowDark = yellow.isDark
+    XCTAssertEqual(isYellowDark, false)
+    
+    let isGreenDark = green.isDark
+    XCTAssertEqual(isGreenDark, false)
+    
+    let isRedDark = red.isDark
+    XCTAssertEqual(isRedDark, true)
+    
+    let isBlueDark = blue.isDark
+    XCTAssertEqual(isBlueDark, true)
+  }
 }

--- a/Source/Mac/NSColor+Hue.swift
+++ b/Source/Mac/NSColor+Hue.swift
@@ -58,39 +58,43 @@ public extension NSColor {
 
     return String(format: "\(prefix)%02X%02X%02X", Int(r * 255), Int(g * 255), Int(b * 255))
   }
+    
+  internal func rgbComponents() -> [CGFloat] {
+    var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
+    usingColorSpace(NSColorSpace.genericRGB)!.getRed(&r, green: &g, blue: &b, alpha: &a)
+    
+    return [r, g, b]
+  }
   
   public var isDark: Bool {
-    guard let RGB = cgColor.components else { return false }
-    let r = RGB[0]
-    let g = RGB[1]
-    let b = RGB[2]
-    return (0.2126 * r + 0.7152 * g + 0.0722 * b) < 0.5
+    let RGB = rgbComponents()
+    return (0.2126 * RGB[0] + 0.7152 * RGB[1] + 0.0722 * RGB[2]) < 0.5
   }
 
   public var isBlackOrWhite: Bool {
-    let RGB = cgColor.components
-    return (RGB![0] > 0.91 && RGB![1] > 0.91 && RGB![2] > 0.91) || (RGB![0] < 0.09 && RGB![1] < 0.09 && RGB![2] < 0.09)
+    let RGB = rgbComponents()
+    return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91) || (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
   }
 
   public var isBlack: Bool {
-    let RGB = cgColor.components
-    return (RGB![0] < 0.09 && RGB![1] < 0.09 && RGB![2] < 0.09)
+    let RGB = rgbComponents()
+    return (RGB[0] < 0.09 && RGB[1] < 0.09 && RGB[2] < 0.09)
   }
 
   public var isWhite: Bool {
-    let RGB = cgColor.components
-    return (RGB![0] > 0.91 && RGB![1] > 0.91 && RGB![2] > 0.91)
+    let RGB = rgbComponents()
+    return (RGB[0] > 0.91 && RGB[1] > 0.91 && RGB[2] > 0.91)
   }
 
   public func isDistinctFrom(_ color: NSColor) -> Bool {
-    let bg = cgColor.components
-    let fg = color.cgColor.components
+    let bg = rgbComponents()
+    let fg = color.rgbComponents()
     let threshold: CGFloat = 0.25
     var result = false
 
-    if fabs((bg?[0])! - (fg?[0])!) > threshold || fabs((bg?[1])! - (fg?[1])!) > threshold || fabs((bg?[2])! - (fg?[2])!) > threshold {
-      if fabs((bg?[0])! - (bg?[1])!) < 0.03 && fabs((bg?[0])! - (bg?[2])!) < 0.03 {
-        if fabs((fg?[0])! - (fg?[1])!) < 0.03 && fabs((fg?[0])! - (fg?[2])!) < 0.03 {
+    if fabs(bg[0] - fg[0]) > threshold || fabs(bg[1] - fg[1]) > threshold || fabs(bg[2] - fg[2]) > threshold {
+      if fabs(bg[0] - bg[1]) < 0.03 && fabs(bg[0] - bg[2]) < 0.03 {
+        if fabs(fg[0] - fg[1]) < 0.03 && fabs(fg[0] - fg[2]) < 0.03 {
           result = false
         }
       }
@@ -111,8 +115,8 @@ public extension NSColor {
       return r + g + b
     }
     
-    let bgComponents = cgColor.components!
-    let fgComponents = color.cgColor.components!
+    let bgComponents = rgbComponents()
+    let fgComponents = color.rgbComponents()
 
     let br = bgComponents[0]
     let bg = bgComponents[1]

--- a/Source/iOS/UIColor+Hue.swift
+++ b/Source/iOS/UIColor+Hue.swift
@@ -58,10 +58,10 @@ public extension UIColor {
   }
 
   internal func rgbComponents() -> [CGFloat] {
-    guard let RGB = cgColor.components, RGB.count == 3 else {
-      return [0,0,0]
-    }
-    return RGB
+    var (r, g, b, a): (CGFloat, CGFloat, CGFloat, CGFloat) = (0.0, 0.0, 0.0, 0.0)
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+    
+    return [r, g, b]
   }
 
   public var isDark: Bool {


### PR DESCRIPTION
This PR fixes #39 

Note: There is still a possibility for edge cases, where `UIColor.specificColor.isDark` is different from `UIColor(hex: UIColor.specificColor.hex()).isDark`, because of the floating point division.  This is also noted in the test cases