### PR TITLE
fixed Swift 4 warnings regarding use of `characters` property

### DIFF
--- a/Source/iOS/UIColor+Hue.swift
+++ b/Source/iOS/UIColor+Hue.swift
@@ -8,15 +8,15 @@ public extension UIColor {
   /// - Parameter hex: A hex string, can either contain # or not
   convenience init(hex string: String) {
     var hex = string.hasPrefix("#")
-      ? String(string.characters.dropFirst())
+      ? String(string.dropFirst())
       : string
-    guard hex.characters.count == 3 || hex.characters.count == 6
+    guard hex.count == 3 || hex.count == 6
       else {
         self.init(white: 1.0, alpha: 0.0)
         return
     }
-    if hex.characters.count == 3 {
-      for (index, char) in hex.characters.enumerated() {
+    if hex.count == 3 {
+      for (index, char) in hex.enumerated() {
         hex.insert(char, at: hex.index(hex.startIndex, offsetBy: index * 2))
       }
     }


### PR DESCRIPTION
Hi,

With Xcode 9 & Swift 4, you get some warnings because the use of the `characters` property is deprecated.
This PR fixes these warnings.

All tests passes.