### PR TITLE
iOS target platform decreased

### DIFF
--- a/Hue.podspec
+++ b/Hue.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '8.0'
   s.ios.source_files = 'Source/iOS/**/*'
   s.ios.frameworks = 'UIKit'
 


### PR DESCRIPTION
There is no reason to bump version to 9.0, there is no code that only work on 9.0 and higher

Fixes https://github.com/hyperoslo/Hue/issues/50