### PR TITLE
fabs is deprecated

### DIFF
--- a/Source/iOS/UIColor+Hue.swift
+++ b/Source/iOS/UIColor+Hue.swift
@@ -96,8 +96,8 @@ public extension UIColor {
     var result = false
     
     if abs(bg[0] - fg[0]) > threshold || abs(bg[1] - fg[1]) > threshold || abs(bg[2] - fg[2]) > threshold {
-      if abs(bg[0] - bg[1]) < 0.03 && abs(bg[0] - bg[2]) < 0.03 {
-        if abs(fg[0] - fg[1]) < 0.03 && abs(fg[0] - fg[2]) < 0.03 {
+        if abs(bg[0] - bg[1]) < 0.03 && abs(bg[0] - bg[2]) < 0.03 {
+            if abs(fg[0] - fg[1]) < 0.03 && abs(fg[0] - fg[2]) < 0.03 {
           result = false
         }
       }


### PR DESCRIPTION
use abs instead

Fixes: https://github.com/hyperoslo/Hue/issues/55