### PR TITLE
Support Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "Hue",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_11),
+        .tvOS(.v9),
+    ],
+    products: [
+        .library(
+            name: "HueAppKit",
+            targets: ["HueAppKit"]),
+        .library(
+            name: "HueUIKit",
+            targets: ["HueUIKit"]),
+    ],
+    targets: [
+        .target(
+            name: "HueAppKit",
+            path: "Source/macOS"),
+        .target(
+            name: "HueUIKit",
+            path: "Source/iOS+tvOS"),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -10,19 +10,13 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "HueAppKit",
-            targets: ["HueAppKit"]),
-        .library(
-            name: "HueUIKit",
-            targets: ["HueUIKit"]),
+            name: "Hue",
+            targets: ["Hue"]),
     ],
     targets: [
         .target(
-            name: "HueAppKit",
-            path: "Source/macOS"),
-        .target(
-            name: "HueUIKit",
-            path: "Source/iOS+tvOS"),
+            name: "Hue",
+            path: "Source"),
     ],
     swiftLanguageVersions: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ github "hyperoslo/Hue"
 To install **Hue** using [Swift Package Manager](https://swift.org/package-manager) with Xcode 11, just follow the instructions at <https://developer.apple.com/documentation/swift_packages> and import the platform specific library to the project:
 
 ```swift
-import HueAppKit // or HueUIKit
+import Hue
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ To install just write into your Cartfile:
 github "hyperoslo/Hue"
 ```
 
+To install **Hue** using [Swift Package Manager](https://swift.org/package-manager) with Xcode 11, just follow the instructions at <https://developer.apple.com/documentation/swift_packages> and import the platform specific library to the project:
+
+```swift
+import HueAppKit // or HueUIKit
+```
+
 ## Author
 
 [Hyper](http://hyper.no) made this with ❤️

--- a/Source/iOS+tvOS/UIColor+Hue.swift
+++ b/Source/iOS+tvOS/UIColor+Hue.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import UIKit
 
 // MARK: - Color Builders
@@ -245,3 +246,4 @@ public extension UIColor {
     return self.add(red: color.redComponent, green: color.greenComponent, blue: color.blueComponent, alpha: color.alphaComponent)
   }
 }
+#endif

--- a/Source/iOS+tvOS/UIImage+Hue.swift
+++ b/Source/iOS+tvOS/UIImage+Hue.swift
@@ -1,3 +1,4 @@
+#if canImport(UIKit)
 import UIKit
 
 class CountedColor {
@@ -174,3 +175,4 @@ extension UIImage {
     }
   }
 }
+#endif

--- a/Source/macOS/NSColor+Hue.swift
+++ b/Source/macOS/NSColor+Hue.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit)
 import AppKit
 
 // MARK: - Color Builders
@@ -258,3 +259,4 @@ public extension NSColor {
     return self.add(red: color.getRed(), green: color.getGreen(), blue: color.getBlue(), alpha: color.getAlpha())
   }
 }
+#endif

--- a/Source/macOS/NSImage+Hue.swift
+++ b/Source/macOS/NSImage+Hue.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit)
 import AppKit
 
 class CountedColor {
@@ -163,3 +164,4 @@ extension NSImage {
       detailColor    ?? (isDarkBackgound ? whiteColor : blackColor))
   }
 }
+#endif


### PR DESCRIPTION
~~Added `Package.swift` that specifies two separate libraries/targets due to different source file paths:~~

- ~~`Source/iOS+tvOS/**/*`~~
- ~~`Source/macOS/**/*`~~

~~Therefore, selecting the platform-specific library is required when adding the package to a project.~~

Introduce `Package.swift` so `Hue` can be added to Xcode projects using Swift Package Manager:

<img width="500" src="https://user-images.githubusercontent.com/2032500/71130675-7196e600-21ea-11ea-8b05-5df4dfdd7d31.png">
 