### PR TITLE
SPM - Fix Xcode warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "Hue",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_11),
         .tvOS(.v9),
     ],


### PR DESCRIPTION
Hue/Package.swift The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.0.99.