### PR TITLE
Catalyst Build Fix

### DIFF
--- a/Source/iOS+tvOS/UIImage+Hue.swift
+++ b/Source/iOS+tvOS/UIImage+Hue.swift
@@ -138,7 +138,9 @@ extension UIImage {
       }
     }
     
-    free(raw)
+      if let raw = raw {
+          free(raw)
+      }
     
     return (
       imageBackgroundColor,

--- a/Source/macOS/NSColor+Hue.swift
+++ b/Source/macOS/NSColor+Hue.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 // MARK: - Color Builders

--- a/Source/macOS/NSImage+Hue.swift
+++ b/Source/macOS/NSImage+Hue.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 class CountedColor {


### PR DESCRIPTION
This is a small change that fixes an error that occurred when using Hue in a Catalyst app. It just adds a condition to not import AppKit when the `targetEnvironment` is `macCatalyst`.

It also fixes an unwrapped optional warning.